### PR TITLE
Modify ucie_sb_driver packet drive behavior

### DIFF
--- a/ucie_sb_driver.sv
+++ b/ucie_sb_driver.sv
@@ -442,13 +442,12 @@ virtual function bit ucie_sb_driver::drive_packet_with_clock(bit [63:0] packet);
   
   // Drive each bit with source-synchronous clock
   for (int i = 0; i < PACKET_SIZE_BITS; i++) begin
-    // Clock low phase - setup data
+    // Clock low phase
     vif.SBTX_CLK = 1'b0;
-    #(cfg.setup_time * 1ns);
-    vif.SBTX_DATA = packet[i];
-    #(cfg.clock_low_time * 1ns - cfg.setup_time * 1ns);
+    #(cfg.clock_low_time * 1ns);
     
-    // Clock high phase - data is valid
+    // Drive data at positive edge of clock
+    vif.SBTX_DATA = packet[i];
     vif.SBTX_CLK = 1'b1;
     #(cfg.clock_high_time * 1ns);
   end


### PR DESCRIPTION
Modify `ucie_sb_driver::drive_packet_with_clock` to drive data at the clock's positive edge without setup time.

---
<a href="https://cursor.com/background-agent?bcId=bc-bf360ba2-2557-4b89-a949-d131cf6a2980">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bf360ba2-2557-4b89-a949-d131cf6a2980">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>